### PR TITLE
install icons in application datadir

### DIFF
--- a/install.py
+++ b/install.py
@@ -27,7 +27,6 @@ prefixDir = '/usr/local'
 buildRoot = '/'
 progName = 'convertall'
 docDir = 'share/doc/{0}'.format(progName)
-iconDir = 'share/icons/{0}'.format(progName)
 
 def usage(exitCode=2):
     """Display usage info and exit.
@@ -38,14 +37,13 @@ def usage(exitCode=2):
     global prefixDir
     global buildRoot
     print('Usage:')
-    print('    python install.py [-h] [-p dir] [-d dir] [-i dir] '
+    print('    python install.py [-h] [-p dir] [-d dir] '
           '[-b dir] [-s] [-x]')
     print('where:')
     print('    -h         display this help message')
     print('    -p dir     install prefix [default: {0}]'.format(prefixDir))
     print('    -d dir     documentaion dir [default: <prefix>/{0}]'
           .format(docDir))
-    print('    -i dir     icon dir [default: <prefix>/{0}]'.format(iconDir))
     print('    -b dir     temporary build root for packagers [default: {0}]'
           .format(buildRoot))
     print('    -s         skip language translation files')
@@ -152,14 +150,13 @@ def removeDir(dir):
 def main():
     """Main installer function.
     """
-    optLetters = 'hp:d:i:b:sx'
+    optLetters = 'hp:d:b:sx'
     try:
         opts, args = getopt.getopt(sys.argv[1:], optLetters)
     except getopt.GetoptError:
         usage(2)
     global prefixDir
     global docDir
-    global iconDir
     global buildRoot
     global progName
     depCheck = True
@@ -171,8 +168,6 @@ def main():
             prefixDir = os.path.abspath(val)
         elif opt == '-d':
             docDir = val
-        elif opt == '-i':
-            iconDir = val
         elif opt == '-b':
             buildRoot = val
         elif opt == '-s':
@@ -263,17 +258,10 @@ def main():
                     'dataFilePath =  \'{0}\'   # modified by install script\n'
                     .format(dataPrefixDir))
     if os.path.isdir('icons'):
-        iconPrefixDir = iconDir.replace('<prefix>/', '')
-        if not os.path.isabs(iconPrefixDir):
-            iconPrefixDir = os.path.join(prefixDir, iconPrefixDir)
+        iconPrefixDir = os.path.join(prefixDir, 'share', progName, 'icons')
         iconBuildDir = os.path.join(buildRoot, iconPrefixDir[1:])
         print('  Copying icon files to {0}'.format(iconBuildDir))
         copyDir('icons', iconBuildDir)
-        # update icon location in main python script
-        replaceLine(os.path.join(pythonBuildDir, '{0}.py'.format(progName)),
-                    'iconPath = None',
-                    'iconPath =  \'{0}\'   # modified by install script\n'
-                    .format(iconPrefixDir))
         if os.path.isfile(os.path.join('icons', progName + '-icon.svg')):
             svgIconPrefixDir = os.path.join(prefixDir, 'share', 'icons',
                                             'hicolor', 'scalable', 'apps')

--- a/source/convertall.py
+++ b/source/convertall.py
@@ -19,7 +19,6 @@ __author__ = 'Doug Bell'
 
 dataFilePath = None    # modified by install script if required
 helpFilePath = None    # modified by install script if required
-iconPath = None        # modified by install script if required
 translationPath = 'translations'
 lang = ''
 

--- a/source/convertdlg.py
+++ b/source/convertdlg.py
@@ -21,12 +21,11 @@ from PyQt5.QtWidgets import (QApplication, QCheckBox, QColorDialog, QDialog,
                              QLabel, QLayout, QMenu, QMessageBox, QPushButton,
                              QSizePolicy, QVBoxLayout, QWidget)
 try:
-    from __main__ import __version__, __author__, helpFilePath, iconPath
+    from __main__ import __version__, __author__, helpFilePath
     from __main__ import lang
 except ImportError:
     __version__ = __author__ = '??'
     helpFilePath = None
-    iconPath = None
     lang = ''
 import unitdata
 from unitgroup import UnitGroup
@@ -54,7 +53,7 @@ class ConvertDlg(QWidget):
         modPath = os.path.abspath(sys.path[0])
         if modPath.endswith('.zip'):  # for py2exe
             modPath = os.path.dirname(modPath)
-        iconPathList = [iconPath, os.path.join(modPath, 'icons/'),
+        iconPathList = [os.path.join(modPath, 'icons/'),
                          os.path.join(modPath, '../icons')]
         self.icons = icondict.IconDict()
         self.icons.addIconPath([path for path in iconPathList if path])

--- a/uninstall.py
+++ b/uninstall.py
@@ -73,7 +73,6 @@ def main():
     removeAll(os.path.join(prefixDir, 'lib', progName))
     removeAll(os.path.join(prefixDir, 'share', 'doc', progName))
     removeAll(os.path.join(prefixDir, 'share', progName))
-    removeAll(os.path.join(prefixDir, 'share', 'icons', progName))
     removeAll(os.path.join(prefixDir, 'share', 'icons', 'hicolor', 'scalable',
                            'apps', progName + '-icon.svg'))
     removeAll(os.path.join(prefixDir, 'share', 'applications',


### PR DESCRIPTION
`$prefix/share/icons` is generally used by XDG icon themes, and the icons installed there by convertall are not structured as such. Since they are application private data rather than public icons, then install them directly inside the data directory of convertall.

This removes the way to setup a custom path for them: it is not needed anymore, as the loading code already looks for an `icons` subdirectory of the directory where the Python modules are.